### PR TITLE
Quickload in battles/conversations

### DIFF
--- a/BetterQuicksave/BetterQuicksave.csproj
+++ b/BetterQuicksave/BetterQuicksave.csproj
@@ -58,6 +58,10 @@
       <HintPath>..\..\..\..\..\Steam\steamapps\common\Mount &amp; Blade II Bannerlord\bin\Win64_Shipping_Client\TaleWorlds.Core.dll</HintPath>
       <Private>False</Private>
     </Reference>
+	<Reference Include="TaleWorlds.DotNet">
+      <HintPath>..\..\..\..\..\Steam\steamapps\common\Mount &amp; Blade II Bannerlord\bin\Win64_Shipping_Client\TaleWorlds.DotNet.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="TaleWorlds.Engine">
       <HintPath>..\..\..\..\Steam\steamapps\common\Mount &amp; Blade II Bannerlord\bin\Win64_Shipping_Client\TaleWorlds.Engine.dll</HintPath>
       <Private>False</Private>

--- a/BetterQuicksave/Source/QuicksaveManager.cs
+++ b/BetterQuicksave/Source/QuicksaveManager.cs
@@ -86,6 +86,17 @@ namespace BetterQuicksave
             return null;
         }
 
+		public static bool isLatestQuicksaveValid() {
+			SaveGameFileInfo[] saveFiles = MBSaveLoad.GetSaveFiles();
+			foreach(SaveGameFileInfo saveFile in saveFiles) {
+				if(IsValidQuicksaveName(saveFile.Name)) {
+					return true;
+				}
+			}
+
+			return false;
+		}
+
         private static int GetCurrentQuicksaveNumber()
         {
             SaveGameFileInfo[] saveFiles = MBSaveLoad.GetSaveFiles();

--- a/BetterQuicksave/Source/QuicksaveManager.cs
+++ b/BetterQuicksave/Source/QuicksaveManager.cs
@@ -8,109 +8,64 @@ using TaleWorlds.Library;
 using TaleWorlds.SaveSystem.Load;
 using TaleWorlds.MountAndBlade;
 
-namespace BetterQuicksave
-{
-    public static class QuicksaveManager
-    {
-        public static bool CanQuickload => Game.Current?.CurrentState == Game.State.Running; //&&
-            //GameStateManager.Current.ActiveState is MapState;
-        static int currentQuicksaveNum = GetCurrentQuicksaveNumber();
+namespace BetterQuicksave {
+	public static class QuicksaveManager {
+		public static bool CanQuickload => Game.Current?.CurrentState == Game.State.Running; //&&
+																							 //GameStateManager.Current.ActiveState is MapState;
+		static int currentQuicksaveNum = GetCurrentQuicksaveNumber();
 
-        public static string GetNewQuicksaveName()
-        {
-            if (currentQuicksaveNum >= Config.MaxQuicksaves)
-            {
-                currentQuicksaveNum = 0;
-            }
+		public static string GetNewQuicksaveName() {
+			if(currentQuicksaveNum >= Config.MaxQuicksaves) {
+				currentQuicksaveNum = 0;
+			}
 
-            string quicksaveName;
-            if (Config.MaxQuicksaves > 1)
-            {
-                quicksaveName = $"{Config.QuicksavePrefix}{++currentQuicksaveNum:000}";
-            }
-            else
-            {
-                quicksaveName = Config.QuicksavePrefix;
-            }
+			string quicksaveName;
+			if(Config.MaxQuicksaves > 1) {
+				quicksaveName = $"{Config.QuicksavePrefix}{++currentQuicksaveNum:000}";
+			} else {
+				quicksaveName = Config.QuicksavePrefix;
+			}
 
-            return quicksaveName;
-        }
+			return quicksaveName;
+		}
 
-        public static bool IsValidQuicksaveName(string name)
-        {
-            return Regex.IsMatch(name, Config.QuicksaveNamePattern);
-        }
+		public static bool IsValidQuicksaveName(string name) {
+			return Regex.IsMatch(name, Config.QuicksaveNamePattern);
+		}
 
-        public static void LoadLatestQuicksave()
-        {
-            LoadGameResult loadGameResult = GetLatestQuicksave();
-            if (loadGameResult == null)
-            {
-                InformationManager.DisplayMessage(new InformationMessage("No quicksaves available."));
-                return;
-            }
-            if (!loadGameResult.LoadResult.Successful)
-            {
-                InformationManager.DisplayMessage(new InformationMessage("Unable to load quicksave:", 
-                    Colors.Yellow));
-                foreach (LoadError loadError in loadGameResult.LoadResult.Errors)
-                {
-                    InformationManager.DisplayMessage(new InformationMessage(loadError.Message, Colors.Red));
-                }
-            }
-            else
-            {
-                ScreenManager.PopScreen();
-                GameStateManager.Current.CleanStates(0);
-                GameStateManager.Current = Module.CurrentModule.GlobalGameStateManager;
-                MBGameManager.StartNewGame(new CampaignGameManager(loadGameResult.LoadResult));
-            }
-        }
+		public static void loadSave(LoadGameResult lgr) {
+			ScreenManager.PopScreen();
+			GameStateManager.Current.CleanStates(0);
+			GameStateManager.Current = Module.CurrentModule.GlobalGameStateManager;
+			MBGameManager.StartNewGame(new CampaignGameManager(lgr.LoadResult));
+		}
 
-        public static void OnQuicksave()
-        {
-            InformationManager.DisplayMessage(new InformationMessage("Quicksaved."));
-        }
+		public static void OnQuicksave() {
+			InformationManager.DisplayMessage(new InformationMessage("Quicksaved."));
+		}
 
-        private static LoadGameResult GetLatestQuicksave()
-        {
-            SaveGameFileInfo[] saveFiles = MBSaveLoad.GetSaveFiles();
-            foreach (SaveGameFileInfo saveFile in saveFiles)
-            {
-                if (IsValidQuicksaveName(saveFile.Name))
-                {
-                    return MBSaveLoad.LoadSaveGameData(saveFile.Name, Utilities.GetModulesNames());
-                }
-            }
-
-            return null;
-        }
-
-		public static bool isLatestQuicksaveValid() {
+		public static LoadGameResult GetLatestQuicksave() {
 			SaveGameFileInfo[] saveFiles = MBSaveLoad.GetSaveFiles();
 			foreach(SaveGameFileInfo saveFile in saveFiles) {
 				if(IsValidQuicksaveName(saveFile.Name)) {
-					return true;
+					return MBSaveLoad.LoadSaveGameData(saveFile.Name, Utilities.GetModulesNames());
 				}
 			}
 
-			return false;
+			return null;
 		}
 
-        private static int GetCurrentQuicksaveNumber()
-        {
-            SaveGameFileInfo[] saveFiles = MBSaveLoad.GetSaveFiles();
-            foreach (SaveGameFileInfo saveFile in saveFiles)
-            {
-                Match match = Regex.Match(saveFile.Name, Config.QuicksaveNamePattern);
-                if (match.Success)
-                {
-                    int.TryParse(match.Groups[1].Value, out int num);
-                    return num;
-                }
-            }
+		private static int GetCurrentQuicksaveNumber() {
+			SaveGameFileInfo[] saveFiles = MBSaveLoad.GetSaveFiles();
+			foreach(SaveGameFileInfo saveFile in saveFiles) {
+				Match match = Regex.Match(saveFile.Name, Config.QuicksaveNamePattern);
+				if(match.Success) {
+					int.TryParse(match.Groups[1].Value, out int num);
+					return num;
+				}
+			}
 
-            return 0;
-        }
-    }
+			return 0;
+		}
+	}
 }

--- a/BetterQuicksave/Source/QuicksaveManager.cs
+++ b/BetterQuicksave/Source/QuicksaveManager.cs
@@ -12,8 +12,8 @@ namespace BetterQuicksave
 {
     public static class QuicksaveManager
     {
-        public static bool CanQuickload => Game.Current?.CurrentState == Game.State.Running &&
-            GameStateManager.Current.ActiveState is MapState;
+        public static bool CanQuickload => Game.Current?.CurrentState == Game.State.Running; //&&
+            //GameStateManager.Current.ActiveState is MapState;
         static int currentQuicksaveNum = GetCurrentQuicksaveNumber();
 
         public static string GetNewQuicksaveName()

--- a/BetterQuicksave/Source/QuicksaveManager.cs
+++ b/BetterQuicksave/Source/QuicksaveManager.cs
@@ -8,64 +8,78 @@ using TaleWorlds.Library;
 using TaleWorlds.SaveSystem.Load;
 using TaleWorlds.MountAndBlade;
 
-namespace BetterQuicksave {
-	public static class QuicksaveManager {
-		public static bool CanQuickload => Game.Current?.CurrentState == Game.State.Running; //&&
-																							 //GameStateManager.Current.ActiveState is MapState;
-		static int currentQuicksaveNum = GetCurrentQuicksaveNumber();
+namespace BetterQuicksave
+{
+    public static class QuicksaveManager
+    {
+        public static bool CanQuickload => Game.Current?.CurrentState == Game.State.Running;
+        static int currentQuicksaveNum = GetCurrentQuicksaveNumber();
 
-		public static string GetNewQuicksaveName() {
-			if(currentQuicksaveNum >= Config.MaxQuicksaves) {
-				currentQuicksaveNum = 0;
-			}
+        public static string GetNewQuicksaveName()
+        {
+            if (currentQuicksaveNum >= Config.MaxQuicksaves)
+            {
+                currentQuicksaveNum = 0;
+            }
 
-			string quicksaveName;
-			if(Config.MaxQuicksaves > 1) {
-				quicksaveName = $"{Config.QuicksavePrefix}{++currentQuicksaveNum:000}";
-			} else {
-				quicksaveName = Config.QuicksavePrefix;
-			}
+            string quicksaveName;
+            if (Config.MaxQuicksaves > 1)
+            {
+                quicksaveName = $"{Config.QuicksavePrefix}{++currentQuicksaveNum:000}";
+            }
+            else
+            {
+                quicksaveName = Config.QuicksavePrefix;
+            }
 
-			return quicksaveName;
-		}
+            return quicksaveName;
+        }
 
-		public static bool IsValidQuicksaveName(string name) {
-			return Regex.IsMatch(name, Config.QuicksaveNamePattern);
-		}
+        public static bool IsValidQuicksaveName(string name)
+        {
+            return Regex.IsMatch(name, Config.QuicksaveNamePattern);
+        }
 
-		public static void loadSave(LoadGameResult lgr) {
-			ScreenManager.PopScreen();
-			GameStateManager.Current.CleanStates(0);
-			GameStateManager.Current = Module.CurrentModule.GlobalGameStateManager;
-			MBGameManager.StartNewGame(new CampaignGameManager(lgr.LoadResult));
-		}
+        public static void loadSave(LoadGameResult lgr) {
+            ScreenManager.PopScreen();
+            GameStateManager.Current.CleanStates(0);
+            GameStateManager.Current = Module.CurrentModule.GlobalGameStateManager;
+            MBGameManager.StartNewGame(new CampaignGameManager(lgr.LoadResult));
+        }
 
-		public static void OnQuicksave() {
-			InformationManager.DisplayMessage(new InformationMessage("Quicksaved."));
-		}
+        public static void OnQuicksave()
+        {
+            InformationManager.DisplayMessage(new InformationMessage("Quicksaved."));
+        }
 
-		public static LoadGameResult GetLatestQuicksave() {
-			SaveGameFileInfo[] saveFiles = MBSaveLoad.GetSaveFiles();
-			foreach(SaveGameFileInfo saveFile in saveFiles) {
-				if(IsValidQuicksaveName(saveFile.Name)) {
-					return MBSaveLoad.LoadSaveGameData(saveFile.Name, Utilities.GetModulesNames());
-				}
-			}
+        public static LoadGameResult GetLatestQuicksave()
+        {
+            SaveGameFileInfo[] saveFiles = MBSaveLoad.GetSaveFiles();
+            foreach (SaveGameFileInfo saveFile in saveFiles)
+            {
+                if (IsValidQuicksaveName(saveFile.Name))
+                {
+                    return MBSaveLoad.LoadSaveGameData(saveFile.Name, Utilities.GetModulesNames());
+                }
+            }
 
-			return null;
-		}
+            return null;
+        }
 
-		private static int GetCurrentQuicksaveNumber() {
-			SaveGameFileInfo[] saveFiles = MBSaveLoad.GetSaveFiles();
-			foreach(SaveGameFileInfo saveFile in saveFiles) {
-				Match match = Regex.Match(saveFile.Name, Config.QuicksaveNamePattern);
-				if(match.Success) {
-					int.TryParse(match.Groups[1].Value, out int num);
-					return num;
-				}
-			}
+        private static int GetCurrentQuicksaveNumber()
+        {
+            SaveGameFileInfo[] saveFiles = MBSaveLoad.GetSaveFiles();
+            foreach (SaveGameFileInfo saveFile in saveFiles)
+            {
+                Match match = Regex.Match(saveFile.Name, Config.QuicksaveNamePattern);
+                if (match.Success)
+                {
+                    int.TryParse(match.Groups[1].Value, out int num);
+                    return num;
+                }
+            }
 
-			return 0;
-		}
-	}
+            return 0;
+        }
+    }
 }

--- a/BetterQuicksave/Source/SubModule.cs
+++ b/BetterQuicksave/Source/SubModule.cs
@@ -4,6 +4,7 @@ using TaleWorlds.Library;
 using TaleWorlds.MountAndBlade;
 using TaleWorlds.Core;
 using TaleWorlds.InputSystem;
+using TaleWorlds.CampaignSystem;
 
 namespace BetterQuicksave
 {
@@ -46,11 +47,26 @@ namespace BetterQuicksave
             }
         }
 
+        private static bool load = false;
+
         protected override void OnApplicationTick(float dt)
         {
+            if(load) {
+                if(GameStateManager.Current.ActiveState is MapState) {
+                    load = false;
+                    if(Mission.Current != null) {
+                        InformationManager.DisplayMessage(new InformationMessage("Mission is not null, failed to quickload!", Colors.Red));
+                    } else {
+                        QuicksaveManager.LoadLatestQuicksave();
+                    }
+                }
+            } else
             if (Input.IsKeyReleased(Config.QuickloadKey) && QuicksaveManager.CanQuickload)
             {
-                QuicksaveManager.LoadLatestQuicksave();   
+				if(Mission.Current != null) {
+					Mission.Current.RetreatMission();
+				}
+				load = true;
             }            
         }
 

--- a/BetterQuicksave/Source/SubModule.cs
+++ b/BetterQuicksave/Source/SubModule.cs
@@ -63,11 +63,15 @@ namespace BetterQuicksave
             } else
             if (Input.IsKeyReleased(Config.QuickloadKey) && QuicksaveManager.CanQuickload)
             {
-				if(Mission.Current != null) {
-					Mission.Current.RetreatMission();
-				}
-				load = true;
-            }            
+                if(QuicksaveManager.isLatestQuicksaveValid()) {
+				    if(Mission.Current != null) {
+					    Mission.Current.RetreatMission();
+				    }
+				    load = true;
+                } else {
+                    InformationManager.DisplayMessage(new InformationMessage("No quicksaves available."));
+                }
+            }
         }
 
         private void DisplayStartupMessages()


### PR DESCRIPTION
I've added the ability to quickload during battles/conversations.
Does this simply by checking if the player is in a mission and forces a retreat before loading.
Had to move some of the code in QuicksaveManager.cs to `OnApplicationTick()` because i needed to check if the save load was successful and the load has to happen in MapState (Loading immediately after calling `Mission.Current.RetreatMission();` interrupts the retreat and thus doesn't reset the mission state).

Not sure if doing this creates other problems, but it works from what i've tested so far.